### PR TITLE
porting to python3

### DIFF
--- a/bin/capture-interface.py
+++ b/bin/capture-interface.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python
+from __future__ import print_function
+from builtins import *
+from builtins import range
 import cli
 import sys
 from csr_aws_guestshell import cag
@@ -31,7 +34,7 @@ for i in range(0, int(args.seconds)):
     sys.stdout.write("\r%d secs" % (i + 1))
     sys.stdout.flush()
 
-print "\n"
+print("\n")
 
 cli.execute("monitor capture PKT_CAP stop")
 cmd = "monitor capture PKT_CAP export bootflash:%s" % filename

--- a/bin/get-metadata.py
+++ b/bin/get-metadata.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
+from __future__ import print_function
+from builtins import *
 import json
 from boto.utils import get_instance_metadata
 
 metadata = get_instance_metadata(timeout=2, num_retries=2)
-print json.dumps(metadata, sort_keys=True,indent=4)
+print(json.dumps(metadata, sort_keys=True,indent=4))

--- a/bin/get-route-table.py
+++ b/bin/get-route-table.py
@@ -1,4 +1,8 @@
 #!/usr/bin/python
+
+from __future__ import print_function
+from builtins import *
+from past.utils import old_div
 import sys
 import getopt
 import json
@@ -20,8 +24,8 @@ subnet_to_route_table = {}
 
 
 def print_instance_header():
-    print "%-30s %-20s %-10s %-15s %-15s %-15s %-10s %-20s" % ("Name", "id", "type", "nametag", "private ip", "Public ip", "state", "launch time")
-    print "-" * 140
+    print("%-30s %-20s %-10s %-15s %-15s %-15s %-10s %-20s" % ("Name", "id", "type", "nametag", "private ip", "Public ip", "state", "launch time"))
+    print("-" * 140)
 
 
 def print_instance_info(i):
@@ -33,26 +37,26 @@ def print_instance_info(i):
 
     # if 'Name' in i.tags:
     #     instance_name = i.tags['Name']
-    print "%-30s %-20s %-10s %-15s %-15s %-15s %-10s %-20s" % \
+    print("%-30s %-20s %-10s %-15s %-15s %-15s %-10s %-20s" % \
         (instance_name[:30], i.id, i.instance_type, i.image_id,
-         i.private_ip_address, i.public_ip_address, i.state['Name'], i.launch_time)
+         i.private_ip_address, i.public_ip_address, i.state['Name'], i.launch_time))
 
 
 def print_metadata_info(metadata):
     region = metadata['placement']['availability-zone'][:-1]
     instance_id = metadata['instance-id']
-    print "Region is %s, Instance Id is %s" % (region, instance_id)
+    print("Region is %s, Instance Id is %s" % (region, instance_id))
     if dump_json:
-        print json.dumps(metadata, sort_keys=True, indent=2)
+	    print(json.dumps(metadata, sort_keys=True, indent=2))
 
 
 def print_vpc_header(vpc_id):
-    sidecnt = (140 - len(vpc_id)) / 2
-    print "\n" * 2 + "=" * sidecnt + vpc_id + "=" * sidecnt
-    print "%-20s %-15s %-10s %-15s %-15s %-15s %-15s %-15s %-15s" % \
+    sidecnt = old_div((140 - len(vpc_id)), 2)
+    print("\n" * 2 + "=" * sidecnt + vpc_id + "=" * sidecnt)
+    print("%-20s %-15s %-10s %-15s %-15s %-15s %-15s %-15s %-15s" % \
         ("Name", "vpc-id", "state", "ipv4-cidr", "ipv6-cidr",
-         "DHCP options", "Route Table", "Network ACL", "Tenancy")
-    print "-" * 140
+         "DHCP options", "Route Table", "Network ACL", "Tenancy"))
+    print("-" * 140)
 
 
 def print_vpc_info(vpc):
@@ -82,9 +86,9 @@ def print_vpc_info(vpc):
         default = "*" + vpc.id
     else:
         default = vpc.id
-    print "%-20s %-15s %-10s %-15s %-15s %-15s %-15s %-15s %-15s" % \
+    print("%-20s %-15s %-10s %-15s %-15s %-15s %-15s %-15s %-15s" % \
         (vpc_name[:30], default, vpc.state, vpc.cidr_block, ipv6_cidr,
-         vpc.dhcp_options_id, route_tbl, acl_id, vpc.instance_tenancy)
+         vpc.dhcp_options_id, route_tbl, acl_id, vpc.instance_tenancy))
 
 
 def print_route_info(vpc):
@@ -106,11 +110,11 @@ def print_route_info(vpc):
     if dump_json:
         print(json.dumps(resp_rt_table, indent=2))
 
-    print "\n* -- interface on this instance"
-    print "%-20s %-20s %-20s %-20s %-20s %-20s %-20s" % \
+    print("\n* -- interface on this instance")
+    print("%-20s %-20s %-20s %-20s %-20s %-19s %-20s" % \
         ("Route Table", "Destination", "Target",
-         "Status", "Assoc id", "subnet", "Propagated")
-    print "-" * 140
+         "Status", "Assoc id", "subnet", "Propagated"))
+    print("-" * 140)
 
     for r in (resp_rt_table['RouteTables']):
         for a in r['Associations']:
@@ -142,9 +146,9 @@ def print_route_info(vpc):
                 destinationblock = route['DestinationCidrBlock']
             else:
                 destinationblock = "NoCidr"
-            print "%-20s %-20s %-20s %-20s %-20s %-20s %-20s" % \
+            print("%-20s %-20s %-20s %-20s %-20s %-20s %-20s" % \
                 (r['RouteTableId'], destinationblock,
-                 gateway, route['State'], rtb_assoc_id, subnet, propagated)
+                 gateway, route['State'], rtb_assoc_id, subnet, propagated))
 
 
 def print_subnet_info(vpc):
@@ -152,19 +156,19 @@ def print_subnet_info(vpc):
 
     subnets = vpc.subnets.all()
 
-    print "\n%-20s %-10s %-15s %-15s %-15s %-20s %-20s %-20s" % \
+    print("\n%-20s %-10s %-15s %-15s %-15s %-20s %-20s %-20s" % \
         ("subnet-id", "state", "vpc-id", "ipv4-cidr",
-         "Available ipv4", "ipv6 cidr", "Avail. Zone", "Route Table")
-    print "-" * 140
+         "Available ipv4", "ipv6 cidr", "Avail. Zone", "Route Table"))
+    print("-" * 140)
 
     for snet in subnets:
         if snet.id in subnet_to_route_table:
             route_table = subnet_to_route_table[snet.id]
         else:
             route_table = subnet_to_route_table['default']
-        print "%-20s %-10s %-15s %-15s %-15s %-20s %-20s %-20s" % \
+        print("%-20s %-10s %-15s %-15s %-15s %-20s %-20s %-20s" % \
             (snet.id, snet.state, snet.vpc_id, snet.cidr_block, snet.available_ip_address_count,
-             snet.ipv6_cidr_block_association_set, snet.availability_zone, route_table)
+             snet.ipv6_cidr_block_association_set, snet.availability_zone, route_table))
 
 
 def get_vpc_info(vpc_id):
@@ -176,7 +180,7 @@ def get_vpc_info(vpc_id):
     vpclist = vpc.instances.all()
     instance_count = sum(1 for _ in vpclist)
     if (instance_count):
-        print "\nVpc %s has %s instances" % (vpc_id, instance_count)
+        print("\nVpc %s has %s instances" % (vpc_id, instance_count))
         print_instance_header()
     for instance in vpclist:
         print_instance_info(instance)
@@ -204,7 +208,7 @@ def main(argv):
                 global dump_json
                 dump_json = 1
     # our instance
-    print "Determining if we are running on AWS..."
+    print("Determining if we are running on AWS...")
     metadata = get_instance_metadata(timeout=2, num_retries=1)
 
     if metadata:
@@ -215,7 +219,7 @@ def main(argv):
             eni = vpc_info["interface-id"]
             vpc_id = vpc_info["vpc-id"]
 
-            print "VPC: %s ENI %s" % (vpc_id, eni)
+            print("VPC: %s ENI %s" % (vpc_id, eni))
             print_vpc_header(vpc_id)
             get_vpc_info(vpc_id)
     else:

--- a/bin/get-stat-drop.py
+++ b/bin/get-stat-drop.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python
+from __future__ import print_function
+from builtins import *
+from past.utils import old_div
 import cli
 import re
 import argparse
@@ -9,15 +12,15 @@ csr = cag()
 
 def print_cmd_output(command, output, print_output):
     if print_output:
-        col_space = (80 - (len(command))) / 2
-        print "\n%s %s %s" % ('=' * col_space, command, '=' * col_space)
-        print "%s \n%s" % (output, '=' * 80)
+        col_space = old_div((80 - (len(command))), 2)
+        print("\n%s %s %s" % ('=' * col_space, command, '=' * col_space))
+        print("%s \n%s" % (output, '=' * 80))
 
 
 def execute_command(command, print_output):
     cmd_output = cli.execute(command)
     while len(cmd_output) == 0:
-        print "CMD FAILED, retrying"
+        print("CMD FAILED, retrying")
         cmd_output = cli.execute(command)
 
     print_cmd_output(command, cmd_output, print_output)
@@ -41,7 +44,7 @@ def get_stat_drop(print_output):
 
         entries = line.split()
         if print_output:
-            print "%s --> %s/%s" % (entries[0], entries[1], entries[2])
+            print("%s --> %s/%s" % (entries[0], entries[1], entries[2]))
         csr.send_metric(entries[0], int(entries[1]), "Statistics drops")
 
 
@@ -81,8 +84,8 @@ def get_datapath_util(print_output):
                 'onehour'), "datapath utilization")
             i = i + 1
 
-def show_gig_interface_summary():
-    cmd_output = execute_command("show interfaces summary")
+def show_gig_interface_summary(print_output):
+    cmd_output = execute_command("show interfaces summary", print_output)
     total_txbps = 0
     total_rxbps = 0
     for line in cmd_output.splitlines():
@@ -154,4 +157,4 @@ if __name__ == "__main__":
     if args.category in ["all", "interface"]:
         show_interface(args.display)
     if args.category in ["all", "interface_summary"]:
-        show_gig_interface_summary()
+        show_gig_interface_summary(args.display)

--- a/bin/get-stat-drop.py
+++ b/bin/get-stat-drop.py
@@ -45,7 +45,7 @@ def get_stat_drop(print_output):
         entries = line.split()
         if print_output:
             print("%s --> %s/%s" % (entries[0], entries[1], entries[2]))
-        csr.send_metric(entries[0], int(entries[1]), "Statistics drops")
+        csr.send_metric(entries[0], (entries[1]), "Statistics drops")
 
 
 def get_datapath_util(print_output):
@@ -69,6 +69,8 @@ def get_datapath_util(print_output):
 
     i = 0
     for line in cmd_output.splitlines():
+        if i >= len(row_names):
+                break
         m = re.search(
             r'.*\s+(?P<fivesecs>\d+)\s+(?P<onemin>\d+)\s+(?P<fivemin>\d+)\s+(?P<onehour>\d+)', line)
         if m:

--- a/bin/load-bin-from-s3.py
+++ b/bin/load-bin-from-s3.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import print_function
+from builtins import *
 import cli
 from csr_aws_guestshell import cag
 import argparse

--- a/bin/load-config-from-s3.py
+++ b/bin/load-config-from-s3.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import print_function
+from builtins import *
 import cli
 from csr_aws_guestshell import cag
 import argparse

--- a/bin/measure-packet-trace.py
+++ b/bin/measure-packet-trace.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
-
+from __future__ import print_function
+from builtins import *
+from builtins import range
+from past.utils import old_div
 import cli
 import sys
 import argparse
@@ -36,10 +39,10 @@ file = open('binaryfile', 'wb')
 output = ''
 packets_retrieved = 0
 start = 0
-num_of_loops = (args.pktcnt / 100) + 1
-time_delay = (int(args.seconds) / num_of_loops)
+num_of_loops = (old_div(args.pktcnt, 100)) + 1
+time_delay = (old_div(int(args.seconds), num_of_loops))
 end = time_delay
-print "executing CLI..."
+print("executing CLI...")
 
 while(args.pktcnt > 0):
     if(args.pktcnt <= 100):
@@ -90,9 +93,9 @@ while(args.pktcnt > 0):
         packets_retrieved += pkt_num
     args.pktcnt = args.pktcnt - 100
 
-print "\n"
-print "Retrieving CLI..."
-print "Retrieved %d packets" % packets_retrieved
+print("\n")
+print("Retrieving CLI...")
+print("Retrieved %d packets" % packets_retrieved)
 features = defaultdict(list)
 packets = {}
 times = []
@@ -102,7 +105,7 @@ start_time = stop_time = ""
 total_time = 0
 packet_num = 0
 
-print "Parsing data..."
+print("Parsing data...")
 
 for line in output.splitlines():
     if "Packet" in line:
@@ -139,32 +142,34 @@ for line in output.splitlines():
 if args.pktnum is not None:
     if args.pktnum in packet_line:
         for line in packet_line[args.pktnum]:
-            print line
+            print(line)
         sys.exit(1)
 
-print "Sorting data..."
+print("Sorting data...")
 
 time_sorted = sorted(times, key=lambda x: x[1])
 if len(time_sorted) > 0:
     max_time_packet = time_sorted[-1][0]
-    print "Min time is packet %s, value %d" % (time_sorted[0][0], time_sorted[0][1])
-    print "Max time is packet %s, value %d" % (max_time_packet, time_sorted[-1][1])
+    print("Min time is packet %s, value %d" % (time_sorted[0][0], time_sorted[0][1]))
+    print("Max time is packet %s, value %d" % (max_time_packet, time_sorted[-1][1]))
     average = float(sum(n for _, n in time_sorted)) / len(time_sorted)
 
 # print "Max Packet:"
 # for line in packets[max_time_packet]:
 #    print line
 
-print "Storing list..."
+print("Storing list...")
 data_list = []
-for feature, tuple_list in features.iteritems():
+for feature, tuple_list in list(features.items()):
     cnt = len(tuple_list)
     total = sum([t[1] for t in tuple_list])
-    pkt_num = t[0]
+    for t in tuple_list:
+        pkt_num = t[0]
+        break
     average = int(float(total) / cnt)
     minimum = min(tuple_list, key=lambda item: item[1])
     maximum = max(tuple_list, key=lambda item: item[1])
-    median = sorted([(lambda x: x[1])(x) for x in tuple_list])[int(cnt / 2)]
+    median = sorted([(lambda x: x[1])(x) for x in tuple_list])[int(old_div(cnt, 2))]
     data_list.append(
         (feature,
          cnt,
@@ -177,10 +182,10 @@ for feature, tuple_list in features.iteritems():
 
 data_sorted = sorted(data_list, key=lambda x: x[5], reverse=True)
 
-print "Printing list..."
+print("Printing list...")
 
-print "%-40s %10s %10s %10s %10s %10s %10s" % ("Feature", "Count", "Packet", "Min", "Max", "Avg", "Med")
-print "-" * 106
+print("%-40s %10s %10s %10s %10s %10s %10s" % ("Feature", "Count", "Packet", "Min", "Max", "Avg", "Med"))
+print("-" * 106)
 for entry in data_sorted:
     feature = entry[0]
     cnt = entry[1]
@@ -190,9 +195,9 @@ for entry in data_sorted:
     maximum = entry[4]
     median = entry[5]
     average = entry[6]
-    print "%-40s %10s %10d %10s %10s %10s %10s" % (feature, cnt, pkt_num, minimum, maximum, average, median)
+    print("%-40s %10s %10d %10s %10s %10s %10s" % (feature, cnt, pkt_num, minimum, maximum, average, median))
 
-with open('/bootflash/' + args.filename, 'wb') as csvfile:
+with open('/bootflash/' + args.filename, 'w') as csvfile:
     csvwriter = csv.writer(csvfile, delimiter=',',
                            quotechar='|', quoting=csv.QUOTE_MINIMAL)
     csvwriter.writerow(["Feature Name",
@@ -214,11 +219,11 @@ with open('/bootflash/' + args.filename, 'wb') as csvfile:
             [feature, cnt, pkt_num, minimum, maximum, average, median])
 
     csvwriter.writerow(["Feature Name", "Packet Number", "Lapsed time"])
-    for feature, tuple_list in features.iteritems():
+    for feature, tuple_list in list(features.items()):
         for t in tuple_list:
             csvwriter.writerow([feature, t[0], t[1]])
 
-    for i, pkt in packets.iteritems():
+    for i, pkt in list(packets.items()):
         for line in pkt:
             csvwriter.writerow([line])
 

--- a/bin/monitor-vpn.py
+++ b/bin/monitor-vpn.py
@@ -1,4 +1,7 @@
 #!/usr/bin/python
+from __future__ import print_function
+from builtins import *
+from past.utils import old_div
 import cli
 import argparse
 
@@ -6,15 +9,15 @@ from csr_aws_guestshell import cag
 
 
 def print_cmd_output(command, output):
-    col_space = (80 - (len(command))) / 2
-    print "\n%s %s %s" % ('=' * col_space, command, '=' * col_space)
-    print "%s \n%s" % (output, '=' * 80)
+    col_space = old_div((80 - (len(command))), 2)
+    print("\n%s %s %s" % ('=' * col_space, command, '=' * col_space))
+    print("%s \n%s" % (output, '=' * 80))
 
 
 def execute_command(command, print_output):
     cmd_output = cli.execute(command)
     while len(cmd_output) == 0:
-        print "CMD FAILED, retrying"
+        print("CMD FAILED, retrying")
         cmd_output = cli.execute(command)
 
     if print_output:
@@ -34,7 +37,7 @@ def get_tunnel_number(print_output):
         if entries[4] == "up" and entries[5] == "up":
             TunnelNumber += 1
 
-    print "TunnelNumber is %s" % (TunnelNumber)
+    print("TunnelNumber is %s" % (TunnelNumber))
     csr.send_metric("TunnelNumber", TunnelNumber, "VPN Status")
 
 

--- a/bin/save-config-to-s3.py
+++ b/bin/save-config-to-s3.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import print_function
+from builtins import *
 import sys
 import cli
 from csr_aws_guestshell import cag
@@ -16,7 +18,7 @@ filename = args.filename
 get_config = "copy running-config bootflash:%s" % filename
 result = cli.execute(get_config)
 if 'copied' not in result:
-    print result
+    print(result)
     sys.exit(1)
 
 result = result.splitlines()
@@ -24,6 +26,6 @@ result = result.splitlines()
 # print output of ios cli output showing the config copy
 for line in result:
     if 'copied' in line:
-        print line
+        print(line)
 
 cag().upload_file(bucket, filename)

--- a/bin/save-tech-support-to-s3.py
+++ b/bin/save-tech-support-to-s3.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import print_function
+from builtins import *
 from csr_aws_guestshell import cag
 import argparse
 

--- a/csr_aws_guestshell/__init__.py
+++ b/csr_aws_guestshell/__init__.py
@@ -1,1 +1,1 @@
-from csr_aws_guestshell import cag
+from .csr_aws_guestshell import cag

--- a/csr_aws_guestshell/csr_aws_guestshell.py
+++ b/csr_aws_guestshell/csr_aws_guestshell.py
@@ -1,4 +1,13 @@
 #!/usr/bin/env python
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
+from builtins import object
+from past.utils import old_div
 import boto3
 import sys
 import threading
@@ -7,7 +16,7 @@ from boto.utils import get_instance_metadata
 # import syslog
 
 
-class cag():
+class cag(object):
     def __init__(self):
         self.metadata = self.get_metadata()
         self.region = self.metadata['placement']['availability-zone'][:-1]
@@ -32,7 +41,7 @@ class cag():
         def __call__(self, bytes_amount):
             with self._lock:
                 self._seen_so_far += bytes_amount
-                percentage = (float(self._seen_so_far) * 100 / self._size)
+                percentage = (old_div(float(self._seen_so_far) * 100, self._size))
 
                 sys.stdout.write(
                     "\r%s  %s / %d  (%.2f%%)" % (
@@ -47,9 +56,9 @@ class cag():
             self.s3_client.download_file(
                 bucket, filename, directory + filename, Callback=self.ProgressPercentage(directory + filename, self))
         except Exception as e:
-            print "Downloading file Failed.  Error: %s" % (e)
+            print("Downloading file Failed.  Error: %s" % (e))
             return False
-        print "\nDownload Complete"
+        print("\nDownload Complete")
         return True
 
     def upload_file(self, bucket, filename, directory="/bootflash/"):
@@ -57,9 +66,9 @@ class cag():
         try:
             self.s3_client.upload_file(directory + filename, bucket, filename)
         except Exception as e:
-            print "Uploading file Failed.  Error: %s" % (e)
+            print("Uploading file Failed.  Error: %s" % (e))
             return False
-        print "Upload Complete to S3 bucket %s" % (bucket)
+        print("Upload Complete to S3 bucket %s" % (bucket))
         return True
 
     def save_cmd_output(self, cmdlist, filename, bucket=None, directory="/bootflash/", print_output=False):
@@ -67,10 +76,10 @@ class cag():
         with open(directory + filename, 'w') as f:
             for command in cmdlist:
                 cmd_output = cli.execute(command)
-                col_space = (80 - (len(command))) / 2
+                col_space = old_div((80 - (len(command))), 2)
                 if print_output is True:
-                    print "\n%s %s %s" % ('=' * col_space, command, '=' * col_space)
-                    print "%s \n%s" % (cmd_output, '=' * 80)
+                    print("\n%s %s %s" % ('=' * col_space, command, '=' * col_space))
+                    print("%s \n%s" % (cmd_output, '=' * 80))
 
                 f.write("\n%s %s %s\n" %
                         ('=' * col_space, command, '=' * col_space))
@@ -97,7 +106,7 @@ class cag():
                         ],
         )
         if response['ResponseMetadata']['HTTPStatusCode'] != 200:
-            print "Error sending %s" % name
+            print("Error sending %s" % name)
 
     def get_metadata(self):
         return get_instance_metadata(timeout=2, num_retries=1)

--- a/csr_aws_guestshell/csr_aws_guestshell.py
+++ b/csr_aws_guestshell/csr_aws_guestshell.py
@@ -1,10 +1,5 @@
 #!/usr/bin/env python
 from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from __future__ import unicode_literals
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 from builtins import object
 from past.utils import old_div

--- a/examples/get-cli-cmds.py
+++ b/examples/get-cli-cmds.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python
+from __future__ import print_function
+from builtins import *
+from builtins import input
+from builtins import object
+from past.utils import old_div
 import argparse
 import os
 import pexpect
@@ -13,7 +18,7 @@ except ImportError:
     guestshell = False
 
 
-class csr_cli():
+class csr_cli(object):
     def __init__(self):
         try:
             imp.find_module('cli')
@@ -114,7 +119,7 @@ class csr_cli():
                 #     continue
 
                 command = command[-60:]
-                col_space = (80 - (len(command) + 4)) / 2
+                col_space = old_div((80 - (len(command) + 4)), 2)
                 total = (col_space * 2) + len(command) + 4 + 2
                 diff = (total - 80) + 1
                 if print_output is not None:
@@ -405,12 +410,12 @@ csr = csr_cli()
 
 if csr.guestshell is False:
     if args.ip is None:
-        hostname = raw_input('hostname: ')
+        hostname = input('hostname: ')
     else:
         hostname = args.ip
 
     if args.user is None:
-        username = raw_input('username: ')
+        username = input('username: ')
     else:
         username = args.user
 

--- a/examples/get-show-cmds.py
+++ b/examples/get-show-cmds.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import print_function
+from builtins import *
 from csr_aws_guestshell import cag
 import argparse
 

--- a/examples/measure-packet-trace.py
+++ b/examples/measure-packet-trace.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python
+from __future__ import print_function
+from builtins import *
+from builtins import range
+from past.utils import old_div
 import cli
 import sys
 import argparse
@@ -126,14 +130,14 @@ if len(time_sorted) > 0:
 
 print "Storing list..."
 data_list = []
-for feature, tuple_list in features.iteritems():
+for feature, tuple_list in list(features.items()):
     cnt = len(tuple_list)
     total = sum([t[1] for t in tuple_list])
     pkt_num = t[0]
     average = int(float(total) / cnt)
     minimum = min(tuple_list, key=lambda item: item[1])
     maximum = max(tuple_list, key=lambda item: item[1])
-    median = sorted([(lambda x: x[1])(x) for x in tuple_list])[int(cnt / 2)]
+    median = sorted([(lambda x: x[1])(x) for x in tuple_list])[int(old_div(cnt, 2))]
     data_list.append((feature, cnt, pkt_num, minimum[
                      1], maximum[1], median, average))
 
@@ -171,10 +175,10 @@ with open('/bootflash/' + args.filename, 'wb') as csvfile:
             [feature, cnt, pkt_num, minimum, maximum, average, median])
 
     csvwriter.writerow(["Feature Name", "Packet Number", "Lapsed time"])
-    for feature, tuple_list in features.iteritems():
+    for feature, tuple_list in list(features.items()):
         for t in tuple_list:
             csvwriter.writerow([feature, t[0], t[1]])
 
-    for i, pkt in packets.iteritems():
+    for i, pkt in list(packets.items()):
         for line in pkt:
             csvwriter.writerow([line])

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 from distutils.core import setup
+import setuptools 
 project_name = 'csr_aws_guestshell'
-project_ver = '0.0.16.dev'
+project_ver = '0.0.17.dev'
 setup(
     name=project_name,
     packages=[project_name],  # this must be the same as the name above
@@ -24,5 +25,6 @@ setup(
         'awscli',
         'boto',
         'boto3',
+        'future',
     ],
 )


### PR DESCRIPTION
ip-10-0-1-110#sh ver
Cisco IOS XE Software, Version 2020-04-29_21.24_croopa
Cisco IOS Software [Amsterdam], Virtual XE Software (X86_64_LINUX_IOSD-UNIVERSALK9-M), Experimental Version 17.3.20200417:065831 [HEAD-/scratch/croopa/workspace/BLD_POLARIS_DEV_LATEST_20200324_000821/polaris 106]
Copyright (c) 1986-2020 by Cisco Systems, Inc.
Compiled Fri 17-Apr-20 03:02 by croopa

[guestshell@guestshell ~]$ get-metadata.py 
{
    "ami-id": "ami-0e42005df1d267e31",
    "ami-launch-index": "0",
    "ami-manifest-path": "(unknown)",
    "block-device-mapping": {
        "ami": "/dev/xvda",
        "root": "/dev/xvda"
    },
    "events": {
        "maintenance": {
            "history": "[]",
            "scheduled": "[]"
        }
    },
    "hostname": "ip-10-0-1-110.ec2.internal",
    "identity-credentials": {
        "ec2": {
            "info": {
                "AccountId": "907962304153",
                "Code": "Success",
                "LastUpdated": "2020-05-12T18:30:22Z"
            },
            "security-credentials": {
                "ec2-instance": {
                    "AccessKeyId": "ASIA5GZWFI2MRVBHEFGX",
                    "Code": "Success",
                    "Expiration": "2020-05-13T00:37:47Z",
                    "LastUpdated": "2020-05-12T18:30:15Z",
                    "SecretAccessKey": "iFgrGDM9eX1wqez+ad/O5YCIRRc+3IkIAdWIAVRT",
                    "Token": "IQoJb3JpZ2luX2VjEAMaCXVzLWVhc3QtMSJIMEYCIQCogbGCeFpsfg9pFbtSLH7SP/gKxLqiuMbgjeUDOzNLMQIhAOpI/7TWV1f45oQhiUgwvhYawjQM8USxMnOu45hb81rkKr8DCEwQARoMOTA3OTYyMzA0MTUzIgwTBTyjW7i6ZG5iig4qnAOpGp+yEVsXxrt2Edl3DbKobjGDK/68SMUl7UgHisb5J7/iAqSDJIIUpPNfQqNekWjq7OAo19KiADbGEoEJDglz6jFS2cISVZqO9+bCSmb2mPwH7/0vzmhBU47t4TJeuY8A2tXiwTvgz8kDtfznnr9iVUt86V6yovXO3NeoIYyrhVETC7tffYr5cNSbDdQRB0LC0Zny5qjVufjEO13/ourv1az0orPmR1rm9XDNrBKYFDDONnePhchAfon0s6jqOh6RPJ4xHuj0LPEYP1RQTlAwT/5kkLt/9iwrzdgbShKidfqqsljTAF5KTLpIb2An6EWSpGYL25ofdiNmpF+E/g9yYuOg3FaNosmByQD9uyAzPCP/0zWPD6khnnAL0SprXw+4oFKi/4mPJ5BV/BW+iusvoc3bSrDI+xW1qXPXyjIcP834MW/X+lHsIqVjVN7uSC0Atpy1bxoR0cLWNddrKdor/xZapcpS1jNXo/MT8qgoAxyj13EiyJJtchHTWUAoxTbocVOfMhHpqTS5rbq3RbRdUHvmq6qwShrVLQFJMMzW6/UFOuYBvXPgRIYDEb2WnBrT8YQvpX+qRijBdyRZZN2x6JIZ6a3IUZz9SMltVMWhGqL1pd2APvbOgHUXNXAJ0pf7eFVOH7+Zv0/5PD1mf6HE020vtjYL6IdX0AuC/sy9sMva0V/NsSM1bzVzsm8oGQRJkWw6frY59vNbwSGWUx3qSicrxtF6mne5CIqeUKPBVnfRQHKM1tsE0Vsznw5k4Ip5PK0agAxSkWUlt6O2MjBs6fjyRQTzj7yJ3xBU37tQ1uraHsMUkDDlA8QvX8j0dR6X0W6zWx1OqojPQgUXwpDIgOXMXY4IqouDgvw=",
                    "Type": "AWS-HMAC"
                }
            }
        }
    },
    "instance-action": "none",
    "instance-id": "i-080d71549a33867cf",
    "instance-type": "c4.large",
    "local-hostname": "ip-10-0-1-110.ec2.internal",
    "local-ipv4": "10.0.1.110",
    "mac": "12:8e:de:b6:a8:9d",
    "metrics": {
        "vhostmd": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
    },
    "network": {
        "interfaces": {
            "macs": {
                "12:8e:de:b6:a8:9d": {
                    "device-number": "0",
                    "interface-id": "eni-076a469ff6d8a4c85",
                    "ipv4-associations": {
                        "3.82.249.198": "10.0.1.110"
                    },
                    "local-hostname": "ip-10-0-1-110.ec2.internal",
                    "local-ipv4s": "10.0.1.110",
                    "mac": "12:8e:de:b6:a8:9d",
                    "owner-id": "907962304153",
                    "public-hostname": "ec2-3-82-249-198.compute-1.amazonaws.com",
                    "public-ipv4s": "3.82.249.198",
                    "security-group-ids": "sg-055ae544f8450f259",
                    "security-groups": "test-csr-host",
                    "subnet-id": "subnet-0fceb0dd102b6a7a2",
                    "subnet-ipv4-cidr-block": "10.0.1.0/24",
                    "vpc-id": "vpc-0aa57f691e69654b4",
                    "vpc-ipv4-cidr-block": "10.0.0.0/16",
                    "vpc-ipv4-cidr-blocks": "10.0.0.0/16"
                }
            }
        }
    },
    "placement": {
        "availability-zone": "us-east-1d"
    },
    "profile": "default-hvm",
    "public-hostname": "ec2-3-82-249-198.compute-1.amazonaws.com",
    "public-ipv4": "3.82.249.198",
    "public-keys": {
        "CSRKey2": [
            "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDGMngzoy68qxIJOzlwbc0qnKLgNYgzqyxUvw/0rq0xMkkzgsesBZdU4JcJVgY8BlQk+tW9D77hjl3hVLLf2wN0A7zPgDMxS7YQXyLZcC6JVNISt0vCJy/h1ArpVEDKDyMqWDSGQNEtvvFqScIWS9uxe13ap4rb8Cbj1tjUN5aXakiURmkgvwVhnG7CPdZ89+NtaH7asmJajt16RP+ZDaF9MEb6J+gNrE5MnU4I6QjJlnDCDO5Tdq7w1CcpYGe5N5LSRUb7VBl0zwXFpgMnX/4kuhnWREEIMEZ1FAcHCOLPIjSOp/MkkUKSYCMmG7uNnbPc+xXKyZcVz3IH+yhe5G7p CSRKey2",
            ""
        ]
    },
    "reservation-id": "r-0e794753e6900b4b4",
    "security-groups": "test-csr-host",
    "services": {
        "domain": "amazonaws.com",
        "partition": "aws"
    }
}

[guestshell@guestshell ~]$ get-route-table.py 
Determining if we are running on AWS...
Region is us-east-1, Instance Id is i-080d71549a33867cf
VPC: vpc-0aa57f691e69654b4 ENI eni-076a469ff6d8a4c85


===========================================================vpc-0aa57f691e69654b4===========================================================
Name                 vpc-id          state      ipv4-cidr       ipv6-cidr       DHCP options    Route Table     Network ACL     Tenancy        
--------------------------------------------------------------------------------------------------------------------------------------------
test                 vpc-0aa57f691e69654b4 available  10.0.0.0/16     []              dopt-5fa08f27   rtb-0ccf4af8c1c8e3b91 acl-00eb963085529c8c5 default        

Vpc vpc-0aa57f691e69654b4 has 18 instances
Name                           id                   type       nametag         private ip      Public ip       state      launch time         
--------------------------------------------------------------------------------------------------------------------------------------------
test-csr                       i-000c0f15d93ff7735  t2.medium  ami-0e6f3f6b62508acfe 10.0.1.107      None            stopped    2019-03-05 22:30:29+00:00
mBWCSRLic_jun26th_4            i-09319b2b07aaf7432  t2.medium  ami-05a80fb306f6d09fd 10.0.1.117      None            stopped    2019-06-28 16:03:08+00:00
mBWCSRLic_jun30_1              i-07e07c36b90b7907d  t2.medium  ami-0cb176e34f613739c 10.0.1.159      None            stopped    2019-06-30 16:35:01+00:00
mBWCSRLicJul5_3                i-0063361135c937974  c4.large   ami-0320748c6a1983f4b 10.0.1.206      None            stopped    2019-07-05 16:44:57+00:00
mBWCSRLicJul5_7                i-0beb777b66d76ecbb  c4.large   ami-0ef1d985187357341 10.0.1.167      None            stopped    2019-07-06 00:28:22+00:00
                               i-05cab8338d0c03fce  c4.large   ami-07e9db346c693e24f 10.0.1.176      None            stopped    2019-07-08 17:26:33+00:00
mbwjul19_1                     i-0ceba353f3e96aed8  c4.large   ami-013475addd3056ebb 10.0.1.198      None            stopped    2019-07-19 15:13:38+00:00
mbwjul19_2                     i-0258a64379f3b1021  c4.large   ami-0d07944dc31a222dc 10.0.1.93       None            stopped    2019-07-19 18:02:11+00:00
mbwjul23_1                     i-0b4902b7e0e075e97  c4.large   ami-04409dea7cb7f9ebd 10.0.1.215      None            stopped    2019-07-23 14:32:04+00:00
openvas-ubuntu                 i-06fe305b68774c6bd  c4.xlarge  ami-00d4e9ff62bc40e03 10.0.1.55       None            stopped    2019-08-12 21:05:46+00:00
2openvas-ubuntu                i-08de3bb9080bed509  c4.xlarge  ami-00d4e9ff62bc40e03 10.0.1.162      None            stopped    2019-08-09 19:50:50+00:00
16_10_b_For_openVAS            i-0509df5001ef26a01  c4.xlarge  ami-0d8a2f539abbd5763 10.0.1.98       None            stopped    2019-08-09 19:50:17+00:00
cdetCsr                        i-0b1d21660806406a0  c4.large   ami-08253623a102646df 10.0.1.32       None            stopped    2019-11-27 15:05:14+00:00
jan_21_linux_1                 i-07e05e65067bd6ec2  t2.micro   ami-0c322300a1dd5dc79 10.0.1.24       None            stopped    2020-02-25 18:48:39+00:00
feb_3_obj_store_testing        i-0ccf96f2fbf038bfd  c5n.large  ami-012edd322fa500083 10.0.1.34       None            stopped    2020-02-03 20:27:04+00:00
feb_6_decode_1                 i-0ce16dd8373d36e6f  c4.large   ami-0116dfe911bdee75d 10.0.1.247      None            stopped    2020-02-06 21:33:37+00:00
us3apr29                       i-080d71549a33867cf  c4.large   ami-0e42005df1d267e31 10.0.1.110      3.82.249.198    running    2020-04-30 01:40:09+00:00
17_2csr                        i-09aec214583c8db78  c4.large   ami-00a09a1fccfb7e946 10.0.1.196      3.95.137.14     running    2020-05-12 14:38:09+00:00

* -- interface on this instance
Route Table          Destination          Target               Status               Assoc id             subnet              Propagated          
--------------------------------------------------------------------------------------------------------------------------------------------
rtb-009b4db29cdbefa0d 10.0.0.0/16          local                active               rtbassoc-08adf6a33dc1cf7f6                      Yes                 
rtb-0a723747bb31cb036 10.0.0.0/16          local                active               rtbassoc-0f7cb39c138b79b12 subnet-0fceb0dd102b6a7a2 Yes                 
rtb-0a723747bb31cb036 0.0.0.0/0            igw-0bf0852a211481158 active               rtbassoc-0f7cb39c138b79b12 subnet-0fceb0dd102b6a7a2 Yes                 
rtb-0ccf4af8c1c8e3b91 10.0.0.0/16          local                active               rtbassoc-0eedbad50128a8937 subnet-014deff5fe8308b08 Yes                 
rtb-0ccf4af8c1c8e3b91 0.0.0.0/0                                 active               rtbassoc-0eedbad50128a8937 subnet-014deff5fe8308b08 Yes                 

subnet-id            state      vpc-id          ipv4-cidr       Available ipv4  ipv6 cidr            Avail. Zone          Route Table         
--------------------------------------------------------------------------------------------------------------------------------------------
subnet-014deff5fe8308b08 available  vpc-0aa57f691e69654b4 10.0.100.0/24   251             []                   us-east-1c           rtb-0ccf4af8c1c8e3b91
subnet-0fceb0dd102b6a7a2 available  vpc-0aa57f691e69654b4 10.0.1.0/24     232             []                   us-east-1d           rtb-0a723747bb31cb036
[guestshell@guestshell ~]$ 
[guestshell@guestshell ~]$ save-config-to-s3.py testconfig45 /guest-share/croopa
7109 bytes copied in 0.057 secs (124719 bytes/sec)
Upload Complete to S3 bucket testconfig45
[guestshell@guestshell ~]$ 
[guestshell@guestshell ~]$ save-tech-support-to-s3.py testconfig45 /guest-share/croopa
Upload Complete to S3 bucket testconfig45
[guestshell@guestshell ~]$ 
load-bin-from-s3.py testconfig45 /guest-share/croopa
/bootflash//guest-share/croopa  1373969 / 1373969  (100.00%)
Download Complete

[guestshell@guestshell ~]$ measure-packet-trace.py --filename /guest-share/packet-trace.csv
executing CLI...
15 secs

Retrieving CLI...
Retrieved 61 packets
Parsing data...
Sorting data...
Min time is packet 56, value 6554
Max time is packet 10, value 51644
Storing list...
Printing list...
Feature                                       Count     Packet        Min        Max        Avg        Med
----------------------------------------------------------------------------------------------------------
 IPV4_NAT_OUTPUT_FIA_EXT                         30         30        665      28316       8950       7947
 IPV4_INPUT_FOR_US_MARTIAN                       24         24        596      12659       6761       4745
 IPV4_NAT_INPUT_FIA_EXT                          24         24        930      10837       5230       4329
 INTERNAL_TRANSMIT_PKT_EXT                       31         31       1094       6787       4307       4015
 MARMOT_SPA_D_TRANSMIT_PKT_EXT                   30         30        653       5438       3094       2962
 LAYER2_OUTPUT_QOS_EXT                            7          7       1677       2270       2027       2148
 LAYER2_OUTPUT_DROP_POLICY_EXT                    7          7       1017       1675       1382       1361
 INTERNAL_INPUT_GOTO_OUTPUT_FEATURE_EXT          30         30        146       1886        903       1014
 IPV4_OUTPUT_L2_REWRITE_EXT                      30         30         64      13251       1112        992
 IPV4_INPUT_LOOKUP_PROCESS_EXT                   54         54         45       1902        697        625
 IPV4_OUTPUT_DROP_POLICY_EXT                     54         54         82       2070        868        608
 IPV4_INTERNAL_FOR_US_EXT                        30         30         51        869        422        495
 IPV4_INTERNAL_DST_LOOKUP_CONSUME_EXT            30         30         51        731        360        402
 IPV4_INPUT_ARL_SANITY                           24         24         77        727        356        290
 IPV4_OUTPUT_VFR_EXT                             30         30         30        657        266        275
 UPDATE_ICMP_PKT_EXT                             30         30         30        421        207        245
 IPV4_INPUT_DST_LOOKUP_ISSUE                     24         24         48       1219        444        244
 IPV4_INPUT_GOTO_OUTPUT_FEATURE_EXT              24         24        151        817        372        244
 IPV4_INTERNAL_INPUT_SRC_LOOKUP_ISSUE_EXT         30         30         44        389        205        213
 DEBUG_COND_INPUT_PKT                            24         24         57        467        207        179
 IPV4_INTERNAL_INPUT_SRC_LOOKUP_CONSUME_EXT         30         30         39        272        152        177
 IPV4_INTERNAL_ARL_SANITY_EXT                    24         24         30        597        227        172
 IPV4_PREF_TX_IF_SELECT_EXT                      30         30         33        436        157        167
 CBUG_OUTPUT_FIA_EXT                             54         54         45        525        206        167
 IPV4_INPUT_IPOPTIONS_PROCESS_EXT                24         24         30        268        157        167
 IPV4_OUTPUT_THREAT_DEFENSE_EXT                  54         54         30        383        192        163
 IPV4_VFR_REFRAG_EXT                             54         54         32      13334        442        143
 IPV4_INPUT_DST_LOOKUP_CONSUME                   24         24         44        367        187        143
 DEBUG_COND_MAC_EGRESS_EXT                       54         54         30        334        152        130
 DEBUG_COND_OUTPUT_PKT_EXT                       61         61         30        528        155        129
 IPV4_INPUT_VFR_EXT                              24         24         42        351        181        120
 DEBUG_COND_APPLICATION_IN_EXT                   54         54         30        288        104        103
 IPV4_OUTPUT_FRAG_EXT                            30         30         30        201         95         97
 DEBUG_COND_INPUT_PKT_EXT                        30         30         30        406        117         86
 LFTS_INJECT_PKT_EXT                             30         30         30        148         94         79
 DEBUG_COND_APPLICATION_OUT_CLR_TXT_EXT          54         54         30        263         62         55
 DEBUG_COND_APPLICATION_OUT_EXT                  54         54         16         70         36         38
 DEBUG_COND_APPLICATION_IN_CLR_TXT_EXT           54         54         16        262         38         36
[guestshell@guestshell ~]$ 

=============
ip-10-0-1-196#ver
% Incomplete command.

ip-10-0-1-196#sh ver
Cisco IOS XE Software, Version BLD_V172_THROTTLE_LATEST_20200509_000537_V17_2_1_32
Cisco IOS Software [Amsterdam], Virtual XE Software (X86_64_LINUX_IOSD-UNIVERSALK9-M), Experimental Version 17.2.20200509:004229 [S2C-build-v172_throttle-2289-/nobackup/mcpre/BLD-BLD_V172_THROTTLE_LATEST_20200509_000537 277]
Copyright (c) 1986-2020 by Cisco Systems, Inc.
Compiled Sat 09-May-20 09:01 by mcpre

get-metadata.py 
{
    "ami-id": "ami-00a09a1fccfb7e946", 
    "ami-launch-index": "0", 
    "ami-manifest-path": "(unknown)", 
    "block-device-mapping": {
        "ami": "/dev/xvda", 
        "root": "/dev/xvda"
    }, 
    "events": {
        "maintenance": {
            "history": "[]", 
            "scheduled": "[]"
        }
    }, 
    "hostname": "ip-10-0-1-196.ec2.internal", 
    "identity-credentials": {}, 
    "instance-action": "none", 
    "instance-id": "i-09aec214583c8db78", 
    "instance-type": "c4.large", 
    "local-hostname": "ip-10-0-1-196.ec2.internal", 
    "local-ipv4": "10.0.1.196", 
    "mac": "12:c0:e4:87:6e:75", 
    "metrics": {
        "vhostmd": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
    }, 
    "network": {
        "interfaces": {
            "macs": {
                "12:c0:e4:87:6e:75": {
                    "device-number": "0", 
                    "interface-id": "eni-09f680e1e0e4355c0", 
                    "ipv4-associations": {
                        "3.95.137.14": "10.0.1.196"
                    }, 
                    "local-hostname": "ip-10-0-1-196.ec2.internal", 
                    "local-ipv4s": "10.0.1.196", 
                    "mac": "12:c0:e4:87:6e:75", 
                    "owner-id": "907962304153", 
                    "public-hostname": "ec2-3-95-137-14.compute-1.amazonaws.com", 
                    "public-ipv4s": "3.95.137.14", 
                    "security-group-ids": "sg-055ae544f8450f259", 
                    "security-groups": "test-csr-host", 
                    "subnet-id": "subnet-0fceb0dd102b6a7a2", 
                    "subnet-ipv4-cidr-block": "10.0.1.0/24", 
                    "vpc-id": "vpc-0aa57f691e69654b4", 
                    "vpc-ipv4-cidr-block": "10.0.0.0/16", 
                    "vpc-ipv4-cidr-blocks": "10.0.0.0/16"
                }
            }
        }
    }, 
    "placement": {
        "availability-zone": "us-east-1d"
    }, 
    "profile": "default-hvm", 
    "public-hostname": "ec2-3-95-137-14.compute-1.amazonaws.com", 
    "public-ipv4": "3.95.137.14", 
    "public-keys": {
        "CSRKey2": [
            "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDGMngzoy68qxIJOzlwbc0qnKLgNYgzqyxUvw/0rq0xMkkzgsesBZdU4JcJVgY8BlQk+tW9D77hjl3hVLLf2wN0A7zPgDMxS7YQXyLZcC6JVNISt0vCJy/h1ArpVEDKDyMqWDSGQNEtvvFqScIWS9uxe13ap4rb8Cbj1tjUN5aXakiURmkgvwVhnG7CPdZ89+NtaH7asmJajt16RP+ZDaF9MEb6J+gNrE5MnU4I6QjJlnDCDO5Tdq7w1CcpYGe5N5LSRUb7VBl0zwXFpgMnX/4kuhnWREEIMEZ1FAcHCOLPIjSOp/MkkUKSYCMmG7uNnbPc+xXKyZcVz3IH+yhe5G7p CSRKey2", 
            ""
        ]
    }, 
    "reservation-id": "r-0bb7e8cfbe09ab6d5", 
    "security-groups": "test-csr-host", 
    "services": {
        "domain": "amazonaws.com", 
        "partition": "aws"
    }
}
 
 
========
[guestshell@guestshell ~]$ save-config-to-s3.py testconfig45 /guest-share/croopa
6944 bytes copied in 0.057 secs (121825 bytes/sec)
Upload Complete to S3 bucket testconfig45
 
====
 
[guestshell@guestshell ~]$ get-route-table.py 
Determining if we are running on AWS...
Region is us-east-1, Instance Id is i-09aec214583c8db78
VPC: vpc-0aa57f691e69654b4 ENI eni-09f680e1e0e4355c0
 
 
===========================================================vpc-0aa57f691e69654b4===========================================================
Name                 vpc-id          state      ipv4-cidr       ipv6-cidr       DHCP options    Route Table     Network ACL     Tenancy        
--------------------------------------------------------------------------------------------------------------------------------------------
test                 vpc-0aa57f691e69654b4 available  10.0.0.0/16     []              dopt-5fa08f27   rtb-0ccf4af8c1c8e3b91 acl-00eb963085529c8c5 default        
 
Vpc vpc-0aa57f691e69654b4 has 18 instances
Name                           id                   type       nametag         private ip      Public ip       state      launch time         
--------------------------------------------------------------------------------------------------------------------------------------------
test-csr                       i-000c0f15d93ff7735  t2.medium  ami-0e6f3f6b62508acfe 10.0.1.107      None            stopped    2019-03-05 22:30:29+00:00
mBWCSRLic_jun26th_4            i-09319b2b07aaf7432  t2.medium  ami-05a80fb306f6d09fd 10.0.1.117      None            stopped    2019-06-28 16:03:08+00:00
mBWCSRLic_jun30_1              i-07e07c36b90b7907d  t2.medium  ami-0cb176e34f613739c 10.0.1.159      None            stopped    2019-06-30 16:35:01+00:00
mBWCSRLicJul5_3                i-0063361135c937974  c4.large   ami-0320748c6a1983f4b 10.0.1.206      None            stopped    2019-07-05 16:44:57+00:00
mBWCSRLicJul5_7                i-0beb777b66d76ecbb  c4.large   ami-0ef1d985187357341 10.0.1.167      None            stopped    2019-07-06 00:28:22+00:00
                               i-05cab8338d0c03fce  c4.large   ami-07e9db346c693e24f 10.0.1.176      None            stopped    2019-07-08 17:26:33+00:00
mbwjul19_1                     i-0ceba353f3e96aed8  c4.large   ami-013475addd3056ebb 10.0.1.198      None            stopped    2019-07-19 15:13:38+00:00
mbwjul19_2                     i-0258a64379f3b1021  c4.large   ami-0d07944dc31a222dc 10.0.1.93       None            stopped    2019-07-19 18:02:11+00:00
mbwjul23_1                     i-0b4902b7e0e075e97  c4.large   ami-04409dea7cb7f9ebd 10.0.1.215      None            stopped    2019-07-23 14:32:04+00:00
openvas-ubuntu                 i-06fe305b68774c6bd  c4.xlarge  ami-00d4e9ff62bc40e03 10.0.1.55       None            stopped    2019-08-12 21:05:46+00:00
2openvas-ubuntu                i-08de3bb9080bed509  c4.xlarge  ami-00d4e9ff62bc40e03 10.0.1.162      None            stopped    2019-08-09 19:50:50+00:00
16_10_b_For_openVAS            i-0509df5001ef26a01  c4.xlarge  ami-0d8a2f539abbd5763 10.0.1.98       None            stopped    2019-08-09 19:50:17+00:00
cdetCsr                        i-0b1d21660806406a0  c4.large   ami-08253623a102646df 10.0.1.32       None            stopped    2019-11-27 15:05:14+00:00
jan_21_linux_1                 i-07e05e65067bd6ec2  t2.micro   ami-0c322300a1dd5dc79 10.0.1.24       None            stopped    2020-02-25 18:48:39+00:00
feb_3_obj_store_testing        i-0ccf96f2fbf038bfd  c5n.large  ami-012edd322fa500083 10.0.1.34       None            stopped    2020-02-03 20:27:04+00:00
feb_6_decode_1                 i-0ce16dd8373d36e6f  c4.large   ami-0116dfe911bdee75d 10.0.1.247      None            stopped    2020-02-06 21:33:37+00:00
us3apr29                       i-080d71549a33867cf  c4.large   ami-0e42005df1d267e31 10.0.1.110      3.82.249.198    running    2020-04-30 01:40:09+00:00
17_2csr                        i-09aec214583c8db78  c4.large   ami-00a09a1fccfb7e946 10.0.1.196      3.95.137.14     running    2020-05-12 14:38:09+00:00
 
* -- interface on this instance
Route Table          Destination          Target               Status               Assoc id             subnet              Propagated          
--------------------------------------------------------------------------------------------------------------------------------------------
rtb-009b4db29cdbefa0d 10.0.0.0/16          local                active               rtbassoc-08adf6a33dc1cf7f6                      Yes                 
rtb-0a723747bb31cb036 10.0.0.0/16          local                active               rtbassoc-0f7cb39c138b79b12 subnet-0fceb0dd102b6a7a2 Yes                 
rtb-0a723747bb31cb036 0.0.0.0/0            igw-0bf0852a211481158 active               rtbassoc-0f7cb39c138b79b12 subnet-0fceb0dd102b6a7a2 Yes                 
rtb-0ccf4af8c1c8e3b91 10.0.0.0/16          local                active               rtbassoc-0eedbad50128a8937 subnet-014deff5fe8308b08 Yes                 
rtb-0ccf4af8c1c8e3b91 0.0.0.0/0                                 active               rtbassoc-0eedbad50128a8937 subnet-014deff5fe8308b08 Yes                 
 
subnet-id            state      vpc-id          ipv4-cidr       Available ipv4  ipv6 cidr            Avail. Zone          Route Table         
--------------------------------------------------------------------------------------------------------------------------------------------
subnet-014deff5fe8308b08 available  vpc-0aa57f691e69654b4 10.0.100.0/24   251             []                   us-east-1c           rtb-0ccf4af8c1c8e3b91
subnet-0fceb0dd102b6a7a2 available  vpc-0aa57f691e69654b4 10.0.1.0/24     232             []                   us-east-1d           rtb-0a723747bb31cb036
==============
[guestshell@guestshell ~]$ save-tech-support-to-s3.py testconfig45 /guest-share/croopa
Upload Complete to S3 bucket testconfig45
===========
 
[guestshell@guestshell ~]$ load-bin-from-s3.py testconfig45 /guest-share/croopa
/bootflash//guest-share/croopa  1373969 / 1373969  (100.00%)
Download Complete
=================
$ measure-packet-trace.py --filename /guest-share/croopa
executing CLI...
15 secs
 
Retrieving CLI...
Retrieved 63 packets
Parsing data...
Sorting data...
Min time is packet 56, value 7995
Max time is packet 7, value 69118
Storing list...
Printing list...
Feature                                       Count     Packet        Min        Max        Avg        Med
----------------------------------------------------------------------------------------------------------
 IPV4_NAT_OUTPUT_FIA_EXT                         31         31      52086     617333     251055     289886
 IPV4_INPUT_FOR_US_MARTIAN                       25         25      52566     252940     136569     188013
 INTERNAL_TRANSMIT_PKT_EXT                       32         32      37680     184246     103651     128433
 IPV4_NAT_INPUT_FIA_EXT                          25         25      45973     196680      98025     118493
 MARMOT_SPA_D_TRANSMIT_PKT_EXT                   31         31      18986     564666      97706      92800
 LAYER2_OUTPUT_QOS_EXT                            7          7      47426      59493      52343      52833
 LAYER2_OUTPUT_DROP_POLICY_EXT                    7          7      28653     249886      65072      34700
 INTERNAL_INPUT_GOTO_OUTPUT_FEATURE_EXT          31         31       5626      44406      22636      32246
 IPV4_OUTPUT_L2_REWRITE_EXT                      31         31       3073     305620      24877      21480
 IPV4_INPUT_LOOKUP_PROCESS_EXT                   56         56       3113      39960      16673      18253
 IPV4_INTERNAL_FOR_US_EXT                        31         31       3093      22866      10519      13493
 IPV4_OUTPUT_DROP_POLICY_EXT                     56         56       4386     297153      27600      13106
 IPV4_INTERNAL_INPUT_SRC_LOOKUP_ISSUE_EXT         31         31        986      14713       6933      10940
 IPV4_INTERNAL_DST_LOOKUP_CONSUME_EXT            31         31       1820      14866       7288       8873
 IPV4_OUTPUT_VFR_EXT                             31         31        526      14020       5585       8313
 UPDATE_ICMP_PKT_EXT                             31         31       1220      12760       5171       7753
 IPV4_INPUT_VFR_EXT                              25         25        520       9360       3902       5486
 IPV4_INPUT_IPOPTIONS_PROCESS_EXT                25         25        913      10400       3663       5146
 IPV4_INPUT_ARL_SANITY                           25         25       2066      16280       5016       5126
 IPV4_INTERNAL_INPUT_SRC_LOOKUP_CONSUME_EXT         31         31       1020       5780       3474       4780
 DEBUG_COND_INPUT_PKT_EXT                        31         31        600       7040       3700       4620
 IPV4_PREF_TX_IF_SELECT_EXT                      31         31       1026       5933       2869       3633
 IPV4_INPUT_GOTO_OUTPUT_FEATURE_EXT              25         25       1953      13053       5021       3480
 IPV4_OUTPUT_THREAT_DEFENSE_EXT                  56         56        213      18193       6517       3206
 IPV4_INPUT_DST_LOOKUP_CONSUME                   25         25        253      10920       3850       3153
 CBUG_OUTPUT_FIA_EXT                             56         56        266      12993       4097       3013
 LFTS_INJECT_PKT_EXT                             31         31        386       3226       1807       2780
 DEBUG_COND_APPLICATION_IN_EXT                   56         56        140       5353       2043       2746
 IPV4_INTERNAL_ARL_SANITY_EXT                    25         25        640       5900       2069       1740
 DEBUG_COND_INPUT_PKT                            25         25        660       7020       1988       1660
 DEBUG_COND_MAC_EGRESS_EXT                       56         56        246     476700      11404       1526
 IPV4_INPUT_DST_LOOKUP_ISSUE                     25         25        273      26966       4899       1486
 IPV4_VFR_REFRAG_EXT                             56         56        193       7286       2533       1373
 DEBUG_COND_OUTPUT_PKT_EXT                       63         63        293       8780       2402       1120
 IPV4_OUTPUT_FRAG_EXT                            31         31        386       3033        996        866
 DEBUG_COND_APPLICATION_OUT_CLR_TXT_EXT          56         56        140       1740        589        386
 DEBUG_COND_APPLICATION_IN_CLR_TXT_EXT           56         56        120       4160        334        246
 DEBUG_COND_APPLICATION_OUT_EXT                  56         56        120       1066        269        233


[guestshell@guestshell ~]$ get-stat-drop.py --display 

============ show platform hardware qfp active statistics drop clear ============
Last clearing of QFP drops statistics : Tue May 12 20:15:18 2020
Global Drop Stats                         Packets        Octets 
----------------------------------------------------------------
   The Global drop stats were all zero 
================================================================================

============= show platform hardware qfp active datapath utilization =============
  CPP 0: Subdev 0            5 secs        1 min        5 min       60 min
Input:  Priority (pps)            0            0            0            0
                 (bps)            0            0            0            0
    Non-Priority (pps)           10           15            5            3
                 (bps)         5752        23552         6016         1616
           Total (pps)           10           15            5            3
                 (bps)         5752        23552         6016         1616
Output: Priority (pps)            0            0            0            0
                 (bps)            0            0            0            0
    Non-Priority (pps)            7           11            4            2
                 (bps)        32936        30784        18624        15392
           Total (pps)            7           11            4            2
                 (bps)        32936        30784        18624        15392
Processing: Load (pct)            2            2            2            2 
================================================================================

============================= show interface summary =============================
 *: interface is up
 IHQ: pkts in input hold queue     IQD: pkts dropped from input queue
 OHQ: pkts in output hold queue    OQD: pkts dropped from output queue
 RXBS: rx rate (bits/sec)          RXPS: rx rate (pkts/sec)
 TXBS: tx rate (bits/sec)          TXPS: tx rate (pkts/sec)
 TRTL: throttle count
  Interface                   IHQ       IQD       OHQ       OQD      RXBS      RXPS      TXBS      TXPS      TRTL
-----------------------------------------------------------------------------------------------------------------
* GigabitEthernet1              0         0         0         0      6000         4      4000         3         0
* VirtualPortGroup0             0         0         0         0      3000         1      5000         2         0 
================================================================================

======================== show interface GigabitEthernet1 ========================
GigabitEthernet1 is up, line protocol is up 
  Hardware is CSR vNIC, address is 12c0.e487.6e75 (bia 12c0.e487.6e75)
  Internet address is 10.0.1.196/24
  MTU 1500 bytes, BW 1000000 Kbit/sec, DLY 10 usec, 
     reliability 255/255, txload 1/255, rxload 1/255
  Encapsulation ARPA, loopback not set
  Keepalive set (10 sec)
  Full Duplex, 1000Mbps, link type is auto, media type is Virtual
  output flow-control is unsupported, input flow-control is unsupported
  ARP type: ARPA, ARP Timeout 04:00:00
  Last input 00:00:01, output 00:00:00, output hang never
  Last clearing of "show interface" counters never
  Input queue: 0/375/0/0 (size/max/drops/flushes); Total output drops: 0
  Queueing strategy: fifo
  Output queue: 0/40 (size/max)
  5 minute input rate 6000 bits/sec, 4 packets/sec
  5 minute output rate 4000 bits/sec, 3 packets/sec
     29407 packets input, 30653903 bytes, 0 no buffer
     Received 0 broadcasts (0 IP multicasts)
     0 runts, 0 giants, 0 throttles 
     0 input errors, 0 CRC, 0 frame, 0 overrun, 0 ignored
     0 watchdog, 0 multicast, 0 pause input
     11573 packets output, 2901918 bytes, 0 underruns
     Output 0 broadcasts (0 IP multicasts)
     0 output errors, 0 collisions, 2 interface resets
     0 unknown protocol drops
     0 babbles, 0 late collision, 0 deferred
     0 lost carrier, 0 no carrier, 0 pause output
     0 output buffer failures, 0 output buffers swapped out 
================================================================================

======================== show interface VirtualPortGroup0 ========================
VirtualPortGroup0 is up, line protocol is up 
  Hardware is Virtual Port Group, address is 001e.49b3.d4bd (bia 001e.49b3.d4bd)
  Internet address is 192.168.35.101/24
  MTU 1500 bytes, BW 750000 Kbit/sec, DLY 1000 usec, 
     reliability 255/255, txload 1/255, rxload 1/255
  Encapsulation ARPA, loopback not set
  Keepalive not supported 
  ARP type: ARPA, ARP Timeout 04:00:00
  Last input 00:15:00, output 00:15:00, output hang never
  Last clearing of "show interface" counters never
  Input queue: 0/375/0/0 (size/max/drops/flushes); Total output drops: 0
  Queueing strategy: fifo
  Output queue: 0/40 (size/max)
  5 minute input rate 3000 bits/sec, 1 packets/sec
  5 minute output rate 5000 bits/sec, 2 packets/sec
     5502 packets input, 1908420 bytes, 0 no buffer
     Received 0 broadcasts (0 IP multicasts)
     0 runts, 0 giants, 0 throttles 
     2 input errors, 0 CRC, 0 frame, 0 overrun, 0 ignored
     0 input packets with dribble condition detected
     22202 packets output, 29994021 bytes, 0 underruns
     Output 0 broadcasts (0 IP multicasts)
     0 output errors, 0 collisions, 0 interface resets
     0 unknown protocol drops
     0 babbles, 0 late collision, 0 deferred
     0 lost carrier, 0 no carrier
     0 output buffer failures, 0 output buffers swapped out 
================================================================================

============================ show interfaces summary ============================
 *: interface is up
 IHQ: pkts in input hold queue     IQD: pkts dropped from input queue
 OHQ: pkts in output hold queue    OQD: pkts dropped from output queue
 RXBS: rx rate (bits/sec)          RXPS: rx rate (pkts/sec)
 TXBS: tx rate (bits/sec)          TXPS: tx rate (pkts/sec)
 TRTL: throttle count
  Interface                   IHQ       IQD       OHQ       OQD      RXBS      RXPS      TXBS      TXPS      TRTL
-----------------------------------------------------------------------------------------------------------------
* GigabitEthernet1              0         0         0         0      6000         4      4000         3         0
* VirtualPortGroup0             0         0         0         0      3000         1      5000         2         0 
================================================================================
[guestshell@guestshell ~]$ 
