### PR TITLE
Prevent runaway command line execs

### DIFF
--- a/bin/get-stat-drop.py
+++ b/bin/get-stat-drop.py
@@ -25,6 +25,9 @@ def execute_command(command, print_output):
         cmd_output = cli.execute(command)
         retries -= 1
 
+    if retries == 0:
+        raise Exception("cli command did not return a valid response")
+
     print_cmd_output(command, cmd_output, print_output)
     return cmd_output
 

--- a/bin/get-stat-drop.py
+++ b/bin/get-stat-drop.py
@@ -19,9 +19,11 @@ def print_cmd_output(command, output, print_output):
 
 def execute_command(command, print_output):
     cmd_output = cli.execute(command)
-    while len(cmd_output) == 0:
+    retries = 3
+    while len(cmd_output) == 0 and retries > 0:
         print("CMD FAILED, retrying")
         cmd_output = cli.execute(command)
+        retries -= 1
 
     print_cmd_output(command, cmd_output, print_output)
     return cmd_output

--- a/bin/monitor-vpn.py
+++ b/bin/monitor-vpn.py
@@ -22,6 +22,9 @@ def execute_command(command, print_output):
         cmd_output = cli.execute(command)
         retries -= 1
 
+    if retries == 0:
+        raise Exception("cli command did not return a valid response")
+
     if print_output:
         print_cmd_output(command, cmd_output)
     return cmd_output

--- a/bin/monitor-vpn.py
+++ b/bin/monitor-vpn.py
@@ -16,9 +16,11 @@ def print_cmd_output(command, output):
 
 def execute_command(command, print_output):
     cmd_output = cli.execute(command)
-    while len(cmd_output) == 0:
+    retries = 3
+    while len(cmd_output) == 0 and retries > 0:
         print("CMD FAILED, retrying")
         cmd_output = cli.execute(command)
+        retries -= 1
 
     if print_output:
         print_cmd_output(command, cmd_output)


### PR DESCRIPTION
We recently installed these scripts on an virtualized CSR 1000V and that was correlated with some new failures that the devices started to experience. We haven't nailed down the precise root cause, but we do believe that the error handling here could've made the problem worse by not eventually failing. 

This pull request changes the calls to `cli.execute` such that a failure to return a CLI response for any reason will no longer retry in an infinite loop.  I wasn't sure whether or not the retry logic had been added to address some transient failures that were normal in IOS world, so I just capped the limit for retries at 3. 